### PR TITLE
ci: build only on main (fixes #7)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build Image
 on:
   repository_dispatch:
   push:
+    branches:
+      - "main"
+      - "#*"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - "main"
-      - "#*"
+#      - "<branch>"
 
 jobs:
   build:


### PR DESCRIPTION
#7 

added the workflow only on `main` branch and the ones which start with `#`